### PR TITLE
Set Tomcat base dir inside target dir

### DIFF
--- a/src/main/java/webapp/runner/launch/Main.java
+++ b/src/main/java/webapp/runner/launch/Main.java
@@ -25,7 +25,7 @@
  */
 package webapp.runner.launch;
 import java.io.File;
-import java.net.URL;
+import java.io.IOException;
 import java.util.Map;
 
 import org.apache.catalina.Context;
@@ -116,7 +116,10 @@ public class Main {
         String webPort = 
         		argMap.containsKey(Argument.PORT) ? argMap.get(Argument.PORT) : "8080";
 
-        tomcat.setPort(Integer.valueOf(webPort));     
+        tomcat.setPort(Integer.valueOf(webPort));
+
+        // set directory for temp files
+        tomcat.setBaseDir(resolveTomcatBaseDir(webPort));
 
         //create a context with the webapp
         String path = argMap.containsKey(Argument.PATH) ? argMap.get(Argument.PATH) : "";
@@ -155,5 +158,26 @@ public class Main {
         //start the server
         tomcat.start();
         tomcat.getServer().await();  
+    }
+
+    /**
+     * Gets or creates temporary Tomcat base directory within target dir
+     *
+     * @param port port of web process
+     * @return absolute dir path
+     * @throws IOException if dir fails to be created
+     */
+    static String resolveTomcatBaseDir(String port) throws IOException {
+        final File baseDir = new File(System.getProperty("user.dir") + "/target/tomcat." + port);
+
+        if (!baseDir.isDirectory() && !baseDir.mkdirs()) {
+            throw new IOException("Could not create temp dir: " + baseDir);
+        }
+
+        try {
+            return baseDir.getCanonicalPath();
+        } catch (IOException e) {
+            return baseDir.getAbsolutePath();
+        }
     }
 }

--- a/src/test/java/webapp/runner/launch/TomcatBaseDirResolutionTest.java
+++ b/src/test/java/webapp/runner/launch/TomcatBaseDirResolutionTest.java
@@ -1,0 +1,58 @@
+package webapp.runner.launch;
+
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.testng.Assert.*;
+
+/**
+ * @author Ryan Brainard
+ */
+public class TomcatBaseDirResolutionTest {
+
+    private static final String PORT = "PORT";
+    private static final File BASE_DIR = new File(System.getProperty("user.dir") + "/target/tomcat." + PORT);
+
+    @BeforeMethod
+    @AfterTest
+    public void clean() {
+        if (BASE_DIR.exists()) {
+            assertTrue(BASE_DIR.delete());
+        }
+    }
+
+    @Test
+    public void testBaseDirNotExists() throws Exception {
+        Main.resolveTomcatBaseDir(PORT);
+        assertTrue(BASE_DIR.isDirectory());
+    }
+
+    @Test
+    public void testBaseDirAlreadyExists() throws Exception {
+        assertTrue(BASE_DIR.mkdirs());
+        Main.resolveTomcatBaseDir(PORT);
+        assertTrue(BASE_DIR.isDirectory());
+    }
+
+    @Test
+    public void testBaseDirAlreadyExistsAsFile() throws Exception {
+        BASE_DIR.getParentFile().mkdirs();
+        new PrintWriter(BASE_DIR).append("");
+        assertTrue(BASE_DIR.isFile());
+
+        try {
+            Main.resolveTomcatBaseDir(PORT);
+            fail();
+        } catch (IOException e) {
+            // expected
+        }
+
+        assertTrue(BASE_DIR.isFile());
+    }
+
+}


### PR DESCRIPTION
This is based on the logic of `org.apache.catalina.startup.Tomcat#initBaseDir`, but adds `/target` to the path the follow the Maven convention of putting all output in `target` so it can be easily deleted with `mvn clean`.
