### PR TITLE
A ROOT webapp context path is actually an empty string

### DIFF
--- a/src/main/java/webapp/runner/launch/CommandLineParams.java
+++ b/src/main/java/webapp/runner/launch/CommandLineParams.java
@@ -28,7 +28,7 @@ public class CommandLineParams {
     public String contextXml;
 
     @Parameter(names = "--path", description = "The context path")
-    public String contextPath = "/";
+    public String contextPath = "";
     
     @Parameter(names = "--shutdown-override", description = "Overrides the default behavior and casues Tomcat to ignore lifecycle failure events rather than shutting down when they occur.")
     public boolean shutdownOverride = false;


### PR DESCRIPTION
Having a `/` as the context path caused issues with JSTL & Spring MVC when using the `<c:url>` tag.  This made URLs with a double slash `//` at the beginning of the URL.  Which causes major problems since a double slash means something special.
