### PR TITLE
Upgrade redis session store library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>ru.zinin</groupId>
             <artifactId>tomcat-redis-session</artifactId>
-            <version>0.4</version>
+            <version>0.5</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>


### PR DESCRIPTION
The .4 version of ru.zinin.tomcat-redis-session uses Jedis 2.0, which causes conflicts when used with other projects that use 2.1(for example, Jesque  - https://github.com/gresrun/jesque).
