### PR TITLE
Should now be able to configure SSL, Client Auth and Basic Auth

### DIFF
--- a/src/main/java/webapp/runner/launch/CommandLineParams.java
+++ b/src/main/java/webapp/runner/launch/CommandLineParams.java
@@ -54,4 +54,12 @@ public class CommandLineParams {
     @Parameter(names = "--compressable-mime-types", description = "Comma delimited list of mime types that will be compressed when using GZIP compression")
     public String compressableMimeTypes = "text/html,text/xml,text/plain,text/css,application/json,application/xml,text/javascript,application/javascript";
 
+    @Parameter(names = "--enable-ssl", description = "Specify -Djavax.net.ssl.trustStore and -Djavax.net.ssl.trustStorePassword in JAVA_OPTS")
+    public boolean enableSSL;
+
+    @Parameter(names = "--enable-client-auth", description = "Specify -Djavax.net.ssl.keyStore and -Djavax.net.ssl.keyStorePassword in JAVA_OPTS")
+    public boolean enableClientAuth;
+
+    @Parameter(names = "--enable-basic-auth", description = "Specify names & roles in tomcat-users.xml file")
+    public boolean enableBasicAuth;
 }


### PR DESCRIPTION
Add the ability to specify truststores and keystores, turn on SSL/TLS, turn on client cert authN, turn on basic authN … and if you do all this … then you actually get a neat little 2-Factor-Authentication (2FA) configured version of tomcat.
