### PR TITLE
Add the ability to specify the URIEncoding of the connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.github.jsimone</groupId>
     <artifactId>webapp-runner</artifactId>
-    <version>7.0.40.1-SNAPSHOT</version>
+    <version>7.0.50.0-SNAPSHOT</version>
 
 
     <name>webapp-runner</name>
@@ -58,7 +58,7 @@
         <source.plugin.version>2.1.2</source.plugin.version>
         <gpg.plugin.version>1.2</gpg.plugin.version>
         <javadoc.plugin.version>2.7</javadoc.plugin.version>
-        <tomcat.version>7.0.40</tomcat.version>
+        <tomcat.version>7.0.50</tomcat.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.github.jsimone</groupId>
     <artifactId>webapp-runner</artifactId>
-    <version>7.0.52.0-SNAPSHOT</version>
+    <version>7.0.53.0-SNAPSHOT</version>
 
 
     <name>webapp-runner</name>
@@ -58,7 +58,7 @@
         <source.plugin.version>2.1.2</source.plugin.version>
         <gpg.plugin.version>1.2</gpg.plugin.version>
         <javadoc.plugin.version>2.7</javadoc.plugin.version>
-        <tomcat.version>7.0.52</tomcat.version>
+        <tomcat.version>7.0.53</tomcat.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.github.jsimone</groupId>
     <artifactId>webapp-runner</artifactId>
-    <version>7.0.50.0-SNAPSHOT</version>
+    <version>7.0.52.0-SNAPSHOT</version>
 
 
     <name>webapp-runner</name>
@@ -58,7 +58,7 @@
         <source.plugin.version>2.1.2</source.plugin.version>
         <gpg.plugin.version>1.2</gpg.plugin.version>
         <javadoc.plugin.version>2.7</javadoc.plugin.version>
-        <tomcat.version>7.0.50</tomcat.version>
+        <tomcat.version>7.0.52</tomcat.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/webapp/runner/launch/CommandLineParams.java
+++ b/src/main/java/webapp/runner/launch/CommandLineParams.java
@@ -3,7 +3,6 @@ package webapp.runner.launch;
 import com.beust.jcommander.Parameter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -74,4 +73,7 @@ public class CommandLineParams {
     
     @Parameter(names = "--expand-war", description = "Expand the war file and set it as source")
     public boolean expandWar = false;
+
+    @Parameter(names = "--uri-encoding", description = "Specify URIEncoding for connector")
+    public String uriEncoding;
 }

--- a/src/main/java/webapp/runner/launch/Main.java
+++ b/src/main/java/webapp/runner/launch/Main.java
@@ -116,6 +116,10 @@ public class Main {
         	nioConnector.setProperty("compressableMimeType", commandLineParams.compressableMimeTypes);
         }
 
+        if(commandLineParams.uriEncoding != null) {
+            nioConnector.setURIEncoding(commandLineParams.uriEncoding);
+        }
+
         tomcat.setConnector(nioConnector);
 
         tomcat.getService().addConnector(tomcat.getConnector());

--- a/src/main/java/webapp/runner/launch/Main.java
+++ b/src/main/java/webapp/runner/launch/Main.java
@@ -239,6 +239,7 @@ public class Main {
      */
     static String resolveTomcatBaseDir(Integer port) throws IOException {
         final File baseDir = new File(System.getProperty("user.dir") + "/target/tomcat." + port);
+        new File(baseDir, "webapps").mkdirs();
 
         if (!baseDir.isDirectory() && !baseDir.mkdirs()) {
             throw new IOException("Could not create temp dir: " + baseDir);

--- a/src/test/java/webapp/runner/launch/TomcatBaseDirResolutionTest.java
+++ b/src/test/java/webapp/runner/launch/TomcatBaseDirResolutionTest.java
@@ -8,6 +8,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import org.apache.commons.io.FileUtils;
+
 import static org.testng.Assert.*;
 
 /**
@@ -20,9 +22,13 @@ public class TomcatBaseDirResolutionTest {
 
     @BeforeMethod
     @AfterTest
-    public void clean() {
+    public void clean() throws IOException {
         if (BASE_DIR.exists()) {
-            assertTrue(BASE_DIR.delete());
+            if(BASE_DIR.isDirectory()) {
+              FileUtils.deleteDirectory(BASE_DIR);
+            } else {
+              BASE_DIR.delete();
+            }
         }
     }
 

--- a/src/test/java/webapp/runner/launch/TomcatBaseDirResolutionTest.java
+++ b/src/test/java/webapp/runner/launch/TomcatBaseDirResolutionTest.java
@@ -16,7 +16,7 @@ import static org.testng.Assert.*;
 public class TomcatBaseDirResolutionTest {
 
     private static final Integer PORT = 1234;
-    private static final File BASE_DIR = new File(System.getProperty("user.dir") + "/target/tomcat." + PORT);
+    private static final File BASE_DIR = new File(System.getProperty("user.dir"), "/target/tomcat." + PORT);
 
     @BeforeMethod
     @AfterTest
@@ -42,7 +42,9 @@ public class TomcatBaseDirResolutionTest {
     @Test
     public void testBaseDirAlreadyExistsAsFile() throws Exception {
         BASE_DIR.getParentFile().mkdirs();
-        new PrintWriter(BASE_DIR).append("");
+        PrintWriter printWriter = new PrintWriter(BASE_DIR);
+        printWriter.append("");
+        printWriter.close();
         assertTrue(BASE_DIR.isFile());
 
         try {


### PR DESCRIPTION
I added the ability to specify the URIEncoding of the connector. It is the equivalent of setting the Attribute URIEncoding of the Connector-element in server.xml. This was necessary to support UTF-8 encoded query parameters.