### PR TITLE
Fix issue with --proxy-base-url not being set to the provided hostname

### DIFF
--- a/main/src/main/java/webapp/runner/launch/Main.java
+++ b/main/src/main/java/webapp/runner/launch/Main.java
@@ -124,6 +124,7 @@ public class Main {
     if (commandLineParams.proxyBaseUrl.length() > 0) {
       URI uri = new URI(commandLineParams.proxyBaseUrl);
       String scheme = uri.getScheme();
+      nioConnector.setProxyName(uri.getHost());
       nioConnector.setScheme(scheme);
       if (scheme.equals("https") && !nioConnector.getSecure()) {
         nioConnector.setSecure(true);


### PR DESCRIPTION
When running behind a proxy, the URL resolution was always being returned as `localhost:<proxy port`.

e.g. passing `--proxy-base-url https://some-domain:3000` would be setup as `localhost:3000`

This fixes the issue by setting the proxy name to the provided URI's host value.