### PR TITLE
Memcached transcoder factory class

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,8 @@ Usage: <main class> [options]
     --use-body-encoding-for-uri
        Set if the entity body encoding should be used for the URI.
        Default: false
-    --transcoder-factory-class
-       The class name of the factory that creates the transcoder to use for serializing/deserializing sessions to/from memcached. Defaults to de.javakaffee.web.msm.JavaSerializationTranscoderFactory
+    --memcached-transcoder-factory-class
+       The class name of the factory that creates the transcoder to use for serializing/deserializing sessions to/from memcached.
     -A
        Allows setting HTTP connector attributes. For example: -Acompression=on
        Syntax: -Akey=value

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ Usage: <main class> [options]
     --use-body-encoding-for-uri
        Set if the entity body encoding should be used for the URI.
        Default: false
+    --transcoder-factory-class
+       The class name of the factory that creates the transcoder to use for serializing/deserializing sessions to/from memcached. Defaults to de.javakaffee.web.msm.JavaSerializationTranscoderFactory
     -A
        Allows setting HTTP connector attributes. For example: -Acompression=on
        Syntax: -Akey=value

--- a/main/src/main/java/webapp/runner/launch/CommandLineParams.java
+++ b/main/src/main/java/webapp/runner/launch/CommandLineParams.java
@@ -104,10 +104,8 @@ public class CommandLineParams {
   @Parameter(names = "--max-threads", description = "Set the maximum number of worker threads")
   public Integer maxThreads = 0;
 
-  @Parameter(names = "--transcoder-factory-class", description = "The class name of the factory that creates the transcoder to use for serializing/deserializing sessions to/from memcached. Defaults to de.javakaffee.web.msm.JavaSerializationTranscoderFactory")
-  public String transcoderFactoryClass = "de.javakaffee.web.msm.JavaSerializationTranscoderFactory";
-
-
+  @Parameter(names = "--memcached-transcoder-factory-class", description = "The class name of the factory that creates the transcoder to use for serializing/deserializing sessions to/from memcached.")
+  public String memcachedTranscoderFactoryClass = null;
 
   @DynamicParameter(
           names = "-A",

--- a/main/src/main/java/webapp/runner/launch/CommandLineParams.java
+++ b/main/src/main/java/webapp/runner/launch/CommandLineParams.java
@@ -104,6 +104,11 @@ public class CommandLineParams {
   @Parameter(names = "--max-threads", description = "Set the maximum number of worker threads")
   public Integer maxThreads = 0;
 
+  @Parameter(names = "--transcoder-factory-class", description = "The class name of the factory that creates the transcoder to use for serializing/deserializing sessions to/from memcached. Defaults to de.javakaffee.web.msm.JavaSerializationTranscoderFactory")
+  public String transcoderFactoryClass = "de.javakaffee.web.msm.JavaSerializationTranscoderFactory";
+
+
+
   @DynamicParameter(
           names = "-A",
           description = "Allows setting HTTP connector attributes. For example: -Acompression=on"

--- a/memcached/src/main/java/webapp/runner/launch/MemcacheSessionStore.java
+++ b/memcached/src/main/java/webapp/runner/launch/MemcacheSessionStore.java
@@ -66,6 +66,9 @@ public class MemcacheSessionStore extends SessionStore {
         manager.setOperationTimeout(commandLineParams.sessionStoreOperationTimout);
         manager.setLockingMode(commandLineParams.sessionStoreLockingMode);
         manager.setRequestUriIgnorePattern(commandLineParams.sessionStoreIgnorePattern);
+
+        manager.setTranscoderFactoryClass(commandLineParams.transcoderFactoryClass);
+
         ctx.setManager(manager);
     }
 

--- a/memcached/src/main/java/webapp/runner/launch/MemcacheSessionStore.java
+++ b/memcached/src/main/java/webapp/runner/launch/MemcacheSessionStore.java
@@ -67,7 +67,9 @@ public class MemcacheSessionStore extends SessionStore {
         manager.setLockingMode(commandLineParams.sessionStoreLockingMode);
         manager.setRequestUriIgnorePattern(commandLineParams.sessionStoreIgnorePattern);
 
-        manager.setTranscoderFactoryClass(commandLineParams.transcoderFactoryClass);
+        if (commandLineParams.memcachedTranscoderFactoryClass != null) {
+            manager.setTranscoderFactoryClass(commandLineParams.memcachedTranscoderFactoryClass);
+        }
 
         ctx.setManager(manager);
     }


### PR DESCRIPTION
I made some adjustments to PR #83 including:

* Change the name of the param to `--memcached-transcoder-factory-class` so the scope is clear to people reading the docs (our other params start with `--session-store`, but really should start wil `--memcached`, but that's because they came before Redis support. le sigh).
* Change the default value of the param to `null`, and don't do anything if it hasn't been set. This will ensure that nothing breaks unexpectedly, but also makes sure the defaults still work when we upgrade memcached-session-manager.

@jaGarcia please review my changes and make sure they are acceptable for you.