### PR TITLE
Added options to enable access logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ $ java -jar webapp-runner.jar --help
 The specified path "src/main/webapp" does not exist.
 Usage: <main class> [options]
   Options:
+    --access-log
+      Enables AccessLogValue to STDOUT
+      Default: false
+    --access-log-pattern
+       If --access-log is enabled, sets the logging pattern
+       Default: common
     --basic-auth-pw
        Password to be used with basic auth. Defaults to BASIC_AUTH_PW env
        variable.

--- a/main/src/main/java/webapp/runner/launch/CommandLineParams.java
+++ b/main/src/main/java/webapp/runner/launch/CommandLineParams.java
@@ -119,4 +119,10 @@ public class CommandLineParams {
   @Parameter(names = "--enable-naming", description = "Enables JNDI naming")
   public boolean enableNaming = false;
 
+  @Parameter(names = "--access-log", description = "Enables AccessLogValue to STDOUT")
+  public boolean accessLog = false;
+
+  @Parameter(names = "--access-log-pattern", description = "If --access-log is enabled, sets the logging pattern")
+  public String accessLogPattern = "common";
+
 }

--- a/main/src/main/java/webapp/runner/launch/Main.java
+++ b/main/src/main/java/webapp/runner/launch/Main.java
@@ -34,16 +34,19 @@ import org.apache.catalina.startup.ExpandWar;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.users.MemoryUserDatabase;
 import org.apache.catalina.users.MemoryUserDatabaseFactory;
+import org.apache.catalina.valves.AccessLogValve;
 import org.apache.coyote.AbstractProtocol;
 import org.apache.coyote.ProtocolHandler;
 import org.apache.tomcat.util.descriptor.web.LoginConfig;
 import org.apache.tomcat.util.descriptor.web.SecurityCollection;
 import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
 import org.apache.tomcat.util.scan.StandardJarScanner;
+import webapp.runner.launch.valves.StdoutAccessLogValve;
 
 import javax.naming.CompositeName;
 import javax.naming.StringRefAddr;
 import javax.servlet.annotation.ServletSecurity.TransportGuarantee;
+import java.io.CharArrayWriter;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -51,6 +54,10 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
 
 /**
  * This is the main entry point to webapp-runner. Helpers are called to parse the arguments. Tomcat configuration and
@@ -268,6 +275,14 @@ public class Main {
 
     if (commandLineParams.enableBasicAuth) {
       enableBasicAuth(ctx, commandLineParams.enableSSL);
+    }
+
+    if (commandLineParams.accessLog) {
+      Host host = tomcat.getHost();
+      StdoutAccessLogValve valve = new StdoutAccessLogValve();
+      valve.setEnabled(true);
+      valve.setPattern(commandLineParams.accessLogPattern);
+      host.getPipeline().addValve(valve);
     }
 
     //start the server

--- a/main/src/main/java/webapp/runner/launch/valves/StdoutAccessLogValve.java
+++ b/main/src/main/java/webapp/runner/launch/valves/StdoutAccessLogValve.java
@@ -1,0 +1,14 @@
+package webapp.runner.launch.valves;
+
+import org.apache.catalina.valves.AbstractAccessLogValve;
+
+import java.io.CharArrayWriter;
+
+public class StdoutAccessLogValve extends AbstractAccessLogValve {
+  @Override
+  public void log(CharArrayWriter message) {
+    synchronized (this) {
+      System.out.println(message.toCharArray());
+    }
+  }
+}


### PR DESCRIPTION
This PR adds two command-line options that enable and configure an [`AccessLogValve`](https://tomcat.apache.org/tomcat-8.5-doc/config/valve.html#Access_Log_Valve) that writes to `System.out` instead of a file.

It can be used like so:

```
java -jar webapp-runner.jar --access-log --access-log-pattern combined myapp.war
```

This resolves part of the request in #110

/cc @dfuentes77 