### PR TITLE
Use FstCodec for redis + upgrade redisson 3.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <memcached-session-manager-tc8.version>2.3.0</memcached-session-manager-tc8.version>
     <source.plugin.version>3.0.1</source.plugin.version>
     <jcommander.version>1.72</jcommander.version>
-    <redisson.version>3.6.5</redisson.version>
+    <redisson.version>3.10.0</redisson.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <invoker.plugin.version>2.0.0</invoker.plugin.version>
     <tomcat.version>8.5.37</tomcat.version>

--- a/redis/src/main/java/webapp/runner/launch/RedisSessionStore.java
+++ b/redis/src/main/java/webapp/runner/launch/RedisSessionStore.java
@@ -3,6 +3,7 @@ package webapp.runner.launch;
 import org.apache.catalina.Context;
 import org.redisson.config.Config;
 import org.redisson.config.SingleServerConfig;
+import org.redisson.codec.FstCodec;
 import org.redisson.tomcat.RedissonSessionManager;
 
 import java.io.BufferedWriter;
@@ -44,6 +45,7 @@ public class RedisSessionStore extends SessionStore {
           .setConnectionPoolSize(commandLineParams.sessionStorePoolSize)
           .setConnectionMinimumIdleSize(commandLineParams.sessionStorePoolSize)
           .setTimeout(commandLineParams.sessionStoreOperationTimout);
+      config.setCodec(new FstCodec());
 
       if (redisUri.getUserInfo() != null) {
         serverConfig.setPassword(redisUri.getUserInfo().substring(redisUri.getUserInfo().indexOf(":")+1));


### PR DESCRIPTION
Fix: https://github.com/jsimone/webapp-runner/issues/126

FstCodec is the default for redisson according to the wiki. Before
webapp-runner would default to JsonJacksonCodec.

A better solution might be to make this config a command line argument. Though in that case it might be preferred to create a new command line argument that feeds the whole redisson config json instead.