### PR TITLE
Fix Tomcat Websocket failure

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -16,9 +16,9 @@
         <artifactId>maven-assembly-plugin</artifactId>
         <version>${assembly.plugin.version}</version>
         <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
+          <descriptors>
+            <descriptor>src/assembly/jar-with-deps-merge-services.xml</descriptor>
+          </descriptors>
           <finalName>${project.artifactId}</finalName>
           <appendAssemblyId>false</appendAssemblyId>
           <archive>

--- a/main/src/assembly/jar-with-deps-merge-services.xml
+++ b/main/src/assembly/jar-with-deps-merge-services.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <!-- copied from jar-with-dependencies (http://maven.apache.org/plugins/maven-assembly-plugin/descriptor-refs.html#jar-with-dependencies) -->
+    <id>jar-with-deps-merge-services</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>


### PR DESCRIPTION
Fix for issue #99 Tomcat 9

The problem is standalone Tomcat has multiple jars and two of them has META-INF/services/javax.servlet.ServletContainerInitializer file. That file contains classes that will be initialized on Tomcat startup. In webapp-runner.jar that file overwritten and includes only org.apache.jasper.servlet.JasperInitializer. For Websockets availability it must include also org.apache.tomcat.websocket.server.WsSci class.

PR fixes assembly configuration for merging META-INF/services.