### PR TITLE
Add missing CHANGELOG entries for latest releases

### DIFF
--- a/webapp-runner-10/CHANGELOG.md
+++ b/webapp-runner-10/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [10.1.54.0] - 2026-04-30
 
+- Update Tomcat to version `10.1.54`. ([#740](https://github.com/heroku/webapp-runner/pull/740))
 
 ## [10.1.53.0] - 2026-04-02
 

--- a/webapp-runner-9/CHANGELOG.md
+++ b/webapp-runner-9/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [9.0.117.0] - 2026-04-30
 
+- Update Tomcat to version `9.0.117`. ([#739](https://github.com/heroku/webapp-runner/pull/739))
 
 ## [9.0.116.0] - 2026-04-02
 


### PR DESCRIPTION
The `9.0.117.0` and `10.1.54.0` release sections were empty. Added the Tomcat-bump entries referencing PRs `#739` and `#740`.